### PR TITLE
Use non-correlated noise for model parameters

### DIFF
--- a/countdown/es_fine-tuning_countdown.py
+++ b/countdown/es_fine-tuning_countdown.py
@@ -132,12 +132,11 @@ def process_seed(seed_args):
     if verbose:
         print(f"Process {accelerator.process_index} Thread {thread_id} processing seed {seed_idx} (value: {seed})")
 
+    gen = torch.Generator(device=param.device)
+    gen.manual_seed(int(seed))
+    
     # Put load-evaluate-restore in the same lock block for thread safety
     for name, param in model.named_parameters():
-        gen = torch.Generator(device=param.device)
-
-        gen.manual_seed(int(seed))
-
         noise = torch.randn(
             param.shape,
             generator=gen,
@@ -157,12 +156,11 @@ def process_seed(seed_args):
                            seed_idx=seed_idx, thread_id=thread_id, verbose=verbose, return_text=False)
     total_reward = sum(rewards)
 
+    gen = torch.Generator(device=param.device)
+    gen.manual_seed(int(seed))
+    
     # Restore original weights (direct inplace modification)
     for name, param in model.named_parameters():
-        gen = torch.Generator(device=param.device)
-
-        gen.manual_seed(int(seed))
-
         noise = torch.randn(
             param.shape,
             generator=gen,

--- a/es_fine-tuning_conciseness.py
+++ b/es_fine-tuning_conciseness.py
@@ -106,12 +106,11 @@ def process_seed(seed_args):
     if verbose:
         print(f"Process {accelerator.process_index} Thread {thread_id} processing seed {seed_idx} (value: {seed})")
 
+    gen = torch.Generator(device=param.device)
+    gen.manual_seed(int(seed))
+    
     # Put load-evaluate-restore in the same lock block for thread safety
     for name, param in model.named_parameters():
-        gen = torch.Generator(device=param.device)
-
-        gen.manual_seed(int(seed))
-
         noise = torch.randn(
             param.shape,
             generator=gen,
@@ -131,12 +130,11 @@ def process_seed(seed_args):
                            seed_idx=seed_idx, thread_id=thread_id, verbose=verbose, return_text=False)
     total_reward = sum(rewards)
 
+    gen = torch.Generator(device=param.device)
+    gen.manual_seed(int(seed))
+    
     # Restore original weights (direct inplace modification)
     for name, param in model.named_parameters():
-        gen = torch.Generator(device=param.device)
-
-        gen.manual_seed(int(seed))
-
         noise = torch.randn(
             param.shape,
             generator=gen,


### PR DESCRIPTION
Original code recreates the `torch.Generator` and uses same seed for each parameter of the model. This results in correlated noise for different model blocks as values in the beginning of each noise tensor will be exactly the same for all parameters.

Updated code seeds the generator only once that results in independent parameter noise. This should improve the convergence a bit.