### PR TITLE
Fix operator precedence bug that disables periodic eval during training

### DIFF
--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -617,7 +617,7 @@ class EvolutionStrategiesTrainer:
                     target_text=target_text,
                 )
 
-                if (iteration+1 % self.eval_freq) == 0 and (iteration > 0):
+                if ((iteration + 1) % self.eval_freq) == 0 and (iteration > 0):
                     self.eval_step(iteration=iteration)
 
                 total_iter_end = time.time()


### PR DESCRIPTION
## Problem

The periodic-eval guard in `EvolutionStrategiesTrainer.fit()` (`es_at_scale/trainer/es_trainer.py`) is:

```python
if (iteration+1 % self.eval_freq) == 0 and (iteration > 0):
```

Because `%` binds tighter than `+` in Python, this parses as `iteration + (1 % eval_freq)`. For any `eval_freq > 1`, `1 % eval_freq == 1`, so the condition becomes `iteration + 1 == 0` — never true. The in-loop `eval_step()` therefore never runs.

The trained weights are unaffected (the ES update in `train_step()` runs every iteration, and `eval_step()` is read-only w.r.t. weights), but two things break:

1. **Periodic eval logging is disabled.** Only the single pre-loop evaluation at iteration 0 runs, so the wandb eval curves contain just the base-model point — no visibility into progress during training.
2. **`save_best_models=True` silently checkpoints the base model.** The only `eval_step()` that executes is the pre-loop one on the un-fine-tuned model. With `best_avg` initialized to `-inf`, that base score is recorded as the "best," so the `checkpoints/<name>-mean<score>/` checkpoint is the untrained base model. No fine-tuned checkpoint is ever saved as best.

Note: the final-iteration checkpoint (`checkpoint-es_fine_tuned_iteration_<N>/`) is always saved at the end of `fit()` regardless, so the documented eval/repro path is unaffected.

## Fix

Parenthesize the addition so eval fires every `eval_freq` iterations as intended:

```python
if ((iteration + 1) % self.eval_freq) == 0 and (iteration > 0):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)