### PR TITLE
Add pluggable inference backends (vLLM + SGLang)

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,107 @@
+# Inference backends
+
+ES-at-scale runs its rollouts and its weight perturbations on a pluggable
+**inference backend**. The trainer (`EvolutionStrategiesTrainer`) is backend-agnostic:
+it holds an `ESBackend` and never imports vLLM or SGLang. Select one at runtime:
+
+```bash
+python es_at_scale/train.py --backend vllm   ...   # default
+python es_at_scale/train.py --backend sglang ...
+```
+
+## The abstraction
+
+`es_at_scale/backends/`:
+
+| file | role |
+|---|---|
+| `base.py` | `ESBackend` ABC, `SamplingConfig`, `GenerationOutput`/`Completion` |
+| `es_ops.py` | the shared ES weight math (perturb / restore / apply_update / snapshot / checksum). **Pure torch — imports no backend.** Installed into every backend env. |
+| `vllm_backend.py` | vLLM engines; ES ops via `collective_rpc` → `WorkerExtension`; update on engine-0 + NCCL broadcast |
+| `sglang_backend.py` | trainer-side driver: spawns out-of-process SGLang workers, ZeroMQ |
+| `sglang_worker.py` | runs in the SGLang env; hosts the engine + ZMQ REP loop |
+| `sglang_shim.py` | subclasses `sglang.Engine` + monkeypatches `es_*` onto the spawned `Scheduler` |
+
+The ES algorithm is written once in `es_ops.py`; each backend only supplies a
+`named_parameters()` accessor, generation, and the cross-engine sync policy.
+
+## vLLM (default)
+
+Unchanged mechanism from the original code, now behind the interface. Runs in the
+**`es-prefix-cache`** conda env (python 3.12 + `vllm==0.11.0` + `transformers==4.57.6`).
+
+```bash
+conda activate es-prefix-cache
+pip install -e ".[vllm]"
+```
+
+## SGLang
+
+SGLang has no vLLM-style in-worker RPC, and its model lives in a spawned child
+process. We inject ES weight ops with a **no-fork in-process shim**: subclass
+`sglang.Engine`, override `run_scheduler_process_func` to monkeypatch `es_*`
+methods (reaching `tp_worker.model_runner.model.named_parameters()`) onto the
+`Scheduler` inside the spawned child, then drive them via `engine.collective_rpc`.
+Only seeds/sampling/prompts cross the wire; noise is regenerated on the GPU.
+
+Because SGLang's dependency tree conflicts with vLLM's, it runs **out-of-process in
+its own conda env**, driven over ZeroMQ. Weight logic mirrors the vLLM backend
+exactly: perturb in place, subtract-restore, apply the committed ES update on
+engine 0, then **NCCL-broadcast** engine-0's weights to every engine each iteration
+(via SGLang's `StatelessProcessGroup`/`PyNccl` inter-engine group — the same
+primitives vLLM uses). Each engine holds only **1× the model weights**; the
+per-iteration broadcast is the tradeoff that scales to large models, versus keeping
+a full-size snapshot per engine (2× VRAM) or a slow CPU-resident one.
+
+### Setup (one-time)
+
+```bash
+conda create -n sglang-es python=3.12 -y
+/home/yinggan/miniconda3/envs/sglang-es/bin/pip install "sglang[all]==0.5.6.post2"
+/home/yinggan/miniconda3/envs/sglang-es/bin/pip install -e "/path/to/es-at-scale[sglang]"   # no vllm
+```
+
+Tell the trainer where that env's python is (either flag or env var):
+
+```bash
+export ES_SGLANG_PYTHON=/home/yinggan/miniconda3/envs/sglang-es/bin/python
+python es_at_scale/train.py --backend sglang --use-gpus 4,5,6,7 --n-vllm-engines 4 ...
+#   or: --sglang-python /home/yinggan/miniconda3/envs/sglang-es/bin/python
+```
+
+### Guardrails (enforced in `sglang_worker.py`)
+
+- `disable_radix_cache=True` — else KV computed under a perturbed model could be
+  reused across weight changes and silently corrupt rewards. **Load-bearing.**
+- `disable_overlap_schedule=True` — deterministic timing vs weight edits.
+- CUDA graphs stay **on** (in-place `copy_`/`add_` preserves param storage).
+- Startup `es_selftest` asserts the shim reached the child and the weight path
+  resolves — a hard failure if the pinned SGLang internals ever move.
+- After each ES step, engine-0's weights are NCCL-broadcast to every engine, so the
+  transient per-engine bf16 drift from subtract-restore is re-synced (identical to
+  vLLM). `checksums()` can verify engines match.
+
+### Constraints / notes
+
+- **Version-pinned to SGLang 0.5.6.post2** (the version whose internals the shim
+  targets). Bumping SGLang requires re-verifying `run_scheduler_process_func`,
+  `collective_rpc`, and `tp_worker.model_runner.model`; the self-test guards it.
+- **N independent TP=1 engines** (one per GPU); `dp_size>1` is not supported. The
+  inter-engine broadcast group is one rank per engine (TP>1 would need per-TP-rank
+  groups, as vLLM does).
+- Each engine holds **1× the model weights** (no snapshot); the committed update is
+  computed on engine 0 and broadcast, so VRAM does not grow with engine count.
+- Generation is not bit-identical to vLLM (different kernels); parity is measured
+  by pass@1 / argmax agreement, not equality.
+
+## Testing
+
+```bash
+# Tier A — deterministic, CPU, no engine:
+python tests/test_es_ops.py
+
+# Tier B — real engines on GPU 4-7:
+python tests/e2e/test_backend.py --backend vllm   --gpus 4,5
+ES_SGLANG_PYTHON=.../sglang-es/bin/python \
+python tests/e2e/test_backend.py --backend sglang --gpus 6,7
+```

--- a/es_at_scale/backends/__init__.py
+++ b/es_at_scale/backends/__init__.py
@@ -1,0 +1,35 @@
+"""Pluggable inference backends for ES.
+
+Import backend implementations LAZILY (only when selected) so that the vLLM and
+SGLang dependency trees -- which live in separate conda environments -- are never
+imported into the same process.
+"""
+
+from es_at_scale.backends.base import (
+    Completion,
+    ESBackend,
+    GenerationOutput,
+    SamplingConfig,
+)
+
+__all__ = [
+    "Completion",
+    "ESBackend",
+    "GenerationOutput",
+    "SamplingConfig",
+    "get_backend",
+]
+
+
+def get_backend(name: str, **cfg) -> ESBackend:
+    """Construct a backend by name. ``**cfg`` is forwarded to its constructor."""
+    name = name.lower()
+    if name == "vllm":
+        from es_at_scale.backends.vllm_backend import VLLMBackend
+
+        return VLLMBackend(**cfg)
+    if name == "sglang":
+        from es_at_scale.backends.sglang_backend import SGLangBackend
+
+        return SGLangBackend(**cfg)
+    raise ValueError(f"Unknown backend '{name}'. Choose from: vllm, sglang.")

--- a/es_at_scale/backends/base.py
+++ b/es_at_scale/backends/base.py
@@ -1,0 +1,115 @@
+"""Backend-neutral interface for ES inference engines.
+
+The trainer holds one :class:`ESBackend` and never imports vllm/sglang. A backend
+owns N inference engines (one population member evaluated per engine at a time)
+and exposes the small set of operations ES needs: greedy generation, per-member
+weight perturbation/restore, the committed ES update, and checkpoint save/load.
+
+Weight-op and generation calls are **async**: each returns an opaque ``Handle``
+that :meth:`ESBackend.wait` resolves, mirroring the trainer's existing
+"issue to all engines, then ``ray.get``" fan-out. For vLLM a ``Handle`` is a Ray
+``ObjectRef``; for SGLang it is a pending-ZMQ-recv token. TensorRT-LLM will wrap
+its executor futures the same way.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+Handle = Any  # opaque per-backend future/token, resolved via ESBackend.wait
+
+
+@dataclass(frozen=True)
+class SamplingConfig:
+    """The only five sampling fields ES ever sets. Defaults are greedy."""
+
+    n: int = 1
+    temperature: float = 0.0
+    top_p: float = 1.0
+    max_tokens: int = 512
+    seed: Optional[int] = None
+
+
+@dataclass
+class Completion:
+    """One sampled continuation for a prompt."""
+
+    text: str
+    token_ids: List[int] = field(default_factory=list)
+
+
+@dataclass
+class GenerationOutput:
+    """Normalized per-prompt result. Mirrors the fields the trainer reads off a
+    vLLM ``RequestOutput``: ``gen.prompt``, ``gen.outputs[i].text``,
+    ``gen.outputs[i].token_ids``."""
+
+    prompt: str
+    outputs: List[Completion] = field(default_factory=list)
+
+
+class ESBackend(ABC):
+    """Interface every inference backend implements for ES."""
+
+    # ------------------------------------------------------------------ lifecycle
+    @property
+    @abstractmethod
+    def num_engines(self) -> int:
+        ...
+
+    @abstractmethod
+    def start(self) -> None:
+        """Launch engines and bring them to a ready state. After ``start`` every
+        engine holds identical weights."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Terminate all engines/subprocesses and free their resources."""
+
+    # -------------------------------------------------------------- async ops
+    @abstractmethod
+    def generate_async(
+        self, engine_idx: int, prompts: List[str], sampling: SamplingConfig
+    ) -> Handle:
+        """Resolves to ``List[GenerationOutput]`` (one per prompt)."""
+
+    @abstractmethod
+    def perturb_async(
+        self, engine_idx: int, seed: int, sigma: float, negate: bool = False
+    ) -> Handle:
+        """Apply ``+/- sigma * randn(seed)`` in place on ``engine_idx``."""
+
+    @abstractmethod
+    def restore_async(self, engine_idx: int, seed: int, sigma: float) -> Handle:
+        """Undo a preceding :meth:`perturb_async` on ``engine_idx`` (returns the
+        engine to its base weights)."""
+
+    @abstractmethod
+    def wait(self, handles: List[Handle]) -> list:
+        """Block until every handle resolves; return results in order."""
+
+    # --------------------------------------------------------- committed update
+    @abstractmethod
+    def sync_after_update(
+        self, seeds, coeffs, alpha: float, population_size: int
+    ) -> None:
+        """Commit the ES gradient step and leave EVERY engine at the identical new
+        weights. Both backends apply the update on engine 0, then NCCL-broadcast
+        engine-0's weights to every engine."""
+
+    # --------------------------------------------------------------- checkpoint
+    @abstractmethod
+    def save(self, path: str, engine_idx: int = 0) -> None:
+        """Save the canonical model weights to ``path`` (raw ES checkpoint)."""
+
+    @abstractmethod
+    def load(self, path: str) -> None:
+        """Load an ES checkpoint into every engine."""
+
+    # ------------------------------------------------------------- drift check
+    def checksums(self) -> List[Optional[tuple]]:
+        """Per-engine weight signatures for cross-engine drift detection.
+        Optional; default returns ``None`` per engine."""
+        return [None] * self.num_engines

--- a/es_at_scale/backends/es_ops.py
+++ b/es_at_scale/backends/es_ops.py
@@ -1,0 +1,144 @@
+"""Backend-agnostic Evolution Strategies weight operations.
+
+This module is the single source of truth for the ES weight math. It is pure
+PyTorch -- it imports only ``torch`` (+ stdlib) and MUST NOT import vllm, sglang,
+ray, or any backend package -- so it can be installed into every backend's conda
+environment (the vLLM trainer env and the SGLang worker env alike) and called
+verbatim from each backend's worker.
+
+The perturb / restore-by-subtraction / update math is lifted unchanged from the
+original ``es_at_scale/utils/worker_extension.py`` so that training dynamics stay
+byte-for-byte identical across backends. :func:`snapshot` / :func:`restore_from_snapshot`
+are generic base-weight helpers, and :func:`checksum` is a cheap signature used to
+verify two engines hold identical weights.
+
+A ``params_fn`` is a zero-argument callable returning a *fresh* iterable of
+``(name, torch.Tensor)`` pairs, e.g. ``lambda: model.named_parameters()``. Every
+function re-invokes it, so a one-shot generator is never exhausted across calls.
+"""
+
+from __future__ import annotations
+
+import gc
+import time
+from typing import Callable, Dict, Iterable, Tuple
+
+import torch
+
+ParamsFn = Callable[[], Iterable[Tuple[str, torch.Tensor]]]
+
+
+def _sync_and_clear() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+
+def _seed_noise(param: torch.Tensor, seed: int) -> torch.Tensor:
+    """Gaussian noise shaped like ``param``, regenerated deterministically from
+    ``seed`` on the parameter's own device/dtype. Identical across processes and
+    engines given the same seed + GPU SKU."""
+    gen = torch.Generator(device=param.device)
+    gen.manual_seed(int(seed))
+    return torch.randn(param.shape, dtype=param.dtype, device=param.device, generator=gen)
+
+
+def perturb(params_fn: ParamsFn, seed: int, noise_scale: float, negate: bool = False) -> None:
+    """In place: ``theta += sign * noise_scale * randn(seed)`` over every param
+    (``sign = -1`` when ``negate``). One population member's exploration step."""
+    sign = -1.0 if negate else 1.0
+    scale = sign * float(noise_scale)
+    for _, p in params_fn():
+        noise = _seed_noise(p, seed)
+        p.data.add_(scale * noise)
+        del noise
+    _sync_and_clear()
+
+
+def restore_subtract(params_fn: ParamsFn, seed: int, sigma: float) -> None:
+    """Exact inverse of ``perturb(seed, sigma, negate=False)`` -- ``theta -=
+    sigma * randn(seed)``. Used by the vLLM backend (whose engine-0 rebroadcast
+    each step masks the bf16 rounding drift)."""
+    perturb(params_fn, seed, sigma, negate=True)
+
+
+def apply_update(
+    params_fn: ParamsFn,
+    seeds,
+    coeffs,
+    alpha: float,
+    population_size: int,
+) -> None:
+    """Commit the ES gradient step:
+    ``theta += (alpha / population_size) * sum_i coeffs[i] * randn(seeds[i])``.
+
+    The per-seed noise is accumulated in float32 before the single ``alpha/N``
+    scaling, then cast back to the parameter dtype -- this preserves the tiny
+    (~1e-5) update signal that would otherwise be truncated in bf16/fp16.
+    ``coeffs[i]`` is the shaped (z-scored) reward of member ``i``.
+    """
+    seeds = [int(s) for s in seeds]
+    coeffs = [float(c) for c in coeffs]
+    scale = float(alpha) / float(population_size)
+    for _, p in params_fn():
+        acc = torch.zeros_like(p.data, dtype=torch.float32)
+        for i, seed in enumerate(seeds):
+            noise = _seed_noise(p, seed)
+            acc.add_(noise.to(torch.float32) * coeffs[i])
+            del noise
+        acc.mul_(scale)
+        p.data.add_(acc.to(p.dtype))
+        del acc
+    _sync_and_clear()
+
+
+def snapshot(params_fn: ParamsFn, device=None) -> Dict[str, torch.Tensor]:
+    """Detached clone of every parameter, forming a base ``theta`` snapshot.
+    ``device=None`` keeps each tensor on its parameter's device (GPU -- fast
+    restore); pass ``"cpu"`` to trade restore speed for VRAM on large models."""
+    base: Dict[str, torch.Tensor] = {}
+    for name, p in params_fn():
+        t = p.detach().clone()
+        base[name] = t.to(device) if device is not None else t
+    return base
+
+
+def restore_from_snapshot(params_fn: ParamsFn, base: Dict[str, torch.Tensor]) -> None:
+    """Bit-exact restore of ``theta`` from a :func:`snapshot` (no rounding drift,
+    unlike :func:`restore_subtract`)."""
+    for name, p in params_fn():
+        p.data.copy_(base[name].to(device=p.device, dtype=p.dtype))
+    _sync_and_clear()
+
+
+def save_to_disk(params_fn: ParamsFn, filepath: str) -> None:
+    """Save weights as a raw ``{name: cpu_tensor}`` ``torch.save`` checkpoint
+    (matches the original ES checkpoint format)."""
+    state_dict = {name: p.detach().cpu() for name, p in params_fn()}
+    torch.save(state_dict, filepath)
+
+
+def load_from_disk(params_fn: ParamsFn, filepath: str, device) -> None:
+    """Load an ES ``{name: tensor}`` checkpoint into the live params in place."""
+    state_dict = torch.load(filepath, map_location=device)
+    for name, p in params_fn():
+        p.data.copy_(state_dict[name].to(device))
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    time.sleep(0.1)
+
+
+def checksum(params_fn: ParamsFn) -> Tuple[int, float, float]:
+    """Cheap order-stable signature ``(num_params, sum, sum_sq)`` in float64.
+    Two engines whose weights are bit-identical produce an identical tuple; used
+    to verify engines match (e.g. after a weight broadcast)."""
+    n = 0
+    total = 0.0
+    total_sq = 0.0
+    for _, p in params_fn():
+        f = p.detach().double()
+        n += 1
+        total += f.sum().item()
+        total_sq += (f * f).sum().item()
+    return (n, total, total_sq)

--- a/es_at_scale/backends/sglang_backend.py
+++ b/es_at_scale/backends/sglang_backend.py
@@ -1,0 +1,278 @@
+"""SGLang implementation of :class:`ESBackend` (trainer side, es-prefix-cache env).
+
+Spawns N out-of-process ES workers with the SGLang env's python (one per engine,
+each GPU-pinned), and drives them over ZeroMQ. Only seeds / sampling / prompts /
+token-ids cross the wire; the seed-driven perturbation runs on the engine GPU.
+
+Weight logic mirrors the vLLM backend: perturb in place, subtract-restore, apply
+the committed ES update on engine 0, then NCCL-broadcast engine-0's weights to every
+engine each iteration (via SGLang's StatelessProcessGroup/PyNccl inter-engine group).
+Each engine holds only 1x the model weights -- no per-engine snapshot -- which is the
+tradeoff that scales to large models.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import socket
+import subprocess
+import uuid
+from typing import List
+
+import zmq
+
+from es_at_scale.backends.base import (
+    Completion,
+    ESBackend,
+    GenerationOutput,
+    Handle,
+    SamplingConfig,
+)
+
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _ZmqHandle:
+    __slots__ = ("engine_idx", "req_id", "convert")
+
+    def __init__(self, engine_idx, req_id, convert=None):
+        self.engine_idx = engine_idx
+        self.req_id = req_id
+        self.convert = convert
+
+
+class SGLangBackend(ESBackend):
+    def __init__(
+        self,
+        model_name: str,
+        n_engines: int,
+        gpus: List[int],
+        n_gpu_per_engine: int = 1,
+        dtype: str = "bfloat16",
+        mem_fraction_static: float = 0.7,
+        seed=None,
+        sglang_python: str = None,
+        disable_cuda_graph: bool = False,
+        op_timeout_s: float = 900.0,
+        start_timeout_s: float = 1200.0,
+    ):
+        self.model_name = model_name
+        self._n_engines = int(n_engines)
+        self.gpus = list(gpus)
+        self.n_gpu_per_engine = int(n_gpu_per_engine)
+        self.dtype = dtype
+        self.mem_fraction_static = mem_fraction_static
+        self.seed = seed
+        self.disable_cuda_graph = disable_cuda_graph
+        self.op_timeout_ms = int(op_timeout_s * 1000)
+        self.start_timeout_ms = int(start_timeout_s * 1000)
+
+        self.sglang_python = sglang_python or os.environ.get("ES_SGLANG_PYTHON")
+        if not self.sglang_python:
+            raise ValueError(
+                "SGLang backend needs the sglang-env python: pass sglang_python "
+                "(--sglang-python) or set $ES_SGLANG_PYTHON."
+            )
+        need = self._n_engines * self.n_gpu_per_engine
+        if len(self.gpus) < need:
+            raise ValueError(
+                f"Need {need} GPUs ({self._n_engines} engines x {self.n_gpu_per_engine}), "
+                f"got {len(self.gpus)}: {self.gpus}"
+            )
+
+        self.ctx = None
+        self.sockets = []
+        self.procs = []
+        self.endpoints = []
+        self._id = 0
+
+    @property
+    def num_engines(self) -> int:
+        return self._n_engines
+
+    def _engine_gpus(self, i):
+        s = i * self.n_gpu_per_engine
+        return self.gpus[s:s + self.n_gpu_per_engine]
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        self.ctx = zmq.Context.instance()
+        run_id = uuid.uuid4().hex[:8]
+        for i in range(self._n_engines):
+            endpoint = f"ipc:///tmp/es-sglang-{os.getpid()}-{run_id}-{i}.sock"
+            self.endpoints.append(endpoint)
+            sock = self.ctx.socket(zmq.REQ)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.connect(endpoint)
+            self.sockets.append(sock)
+
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in self._engine_gpus(i))
+            env["PYTHONPATH"] = _REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+            # The worker runs the sglang-env python but inherits our (trainer-env)
+            # PATH/LD_LIBRARY_PATH. Put the sglang env's bin first so its build tools
+            # (ninja) and console scripts resolve; drop the trainer's LD_LIBRARY_PATH
+            # so the sglang torch loads its own bundled CUDA libs; and make a CUDA
+            # toolkit's nvcc available for any flashinfer/torch JIT fallback.
+            sglang_bin = os.path.dirname(os.path.abspath(self.sglang_python))
+            path_parts = [sglang_bin]
+            if not env.get("CUDA_HOME"):
+                for cand in ("/usr/local/cuda", "/usr/local/cuda-12.9"):
+                    if os.path.isdir(cand):
+                        env["CUDA_HOME"] = cand
+                        break
+            if env.get("CUDA_HOME"):
+                path_parts.append(os.path.join(env["CUDA_HOME"], "bin"))
+            env["PATH"] = os.pathsep.join(path_parts + [env.get("PATH", "")])
+            env.pop("LD_LIBRARY_PATH", None)
+            cmd = [
+                self.sglang_python, "-m", "es_at_scale.backends.sglang_worker",
+                "--model", self.model_name,
+                "--endpoint", endpoint,
+                "--tp-size", str(self.n_gpu_per_engine),
+                "--mem-fraction-static", str(self.mem_fraction_static),
+                "--dtype", self.dtype,
+                "--random-seed", str((self.seed or 42) + i),
+            ]
+            if self.disable_cuda_graph:
+                cmd.append("--disable-cuda-graph")
+            self.procs.append(subprocess.Popen(cmd, env=env))
+
+        # Block until every worker's engine is up (model load + graph capture).
+        for i in range(self._n_engines):
+            h = self._send(i, {"op": "ping"})
+            self._recv_one(h, timeout_ms=self.start_timeout_ms)
+
+        # Build the inter-engine NCCL broadcast group (engine 0 -> all). The init
+        # is a collective rendezvous, so fire it on every engine before waiting.
+        if self._n_engines > 1:
+            master_address, master_port = "127.0.0.1", _free_port()
+            self.wait([
+                self._send(i, {"op": "init_broadcast_group",
+                               "master_address": master_address, "master_port": master_port,
+                               "rank": i, "world_size": self._n_engines})
+                for i in range(self._n_engines)
+            ])
+
+    def shutdown(self) -> None:
+        for i, sock in enumerate(self.sockets):
+            try:
+                sock.send(pickle.dumps({"op": "shutdown", "id": self._next_id()}))
+                sock.RCVTIMEO = 10000
+                sock.recv()
+            except Exception:
+                pass
+        for p in self.procs:
+            try:
+                p.terminate()
+                p.wait(timeout=15)
+            except Exception:
+                try:
+                    p.kill()
+                except Exception:
+                    pass
+        for sock in self.sockets:
+            try:
+                sock.close(0)
+            except Exception:
+                pass
+        self.sockets, self.procs, self.endpoints = [], [], []
+
+    # -------------------------------------------------------------- messaging
+    def _next_id(self):
+        self._id += 1
+        return self._id
+
+    def _send(self, engine_idx, msg, convert=None) -> _ZmqHandle:
+        rid = self._next_id()
+        msg = dict(msg)
+        msg["id"] = rid
+        self.sockets[engine_idx].send(pickle.dumps(msg))
+        return _ZmqHandle(engine_idx, rid, convert)
+
+    def _recv_one(self, handle: _ZmqHandle, timeout_ms=None):
+        sock = self.sockets[handle.engine_idx]
+        if not sock.poll(timeout_ms if timeout_ms is not None else self.op_timeout_ms):
+            raise RuntimeError(
+                f"SGLang engine {handle.engine_idx} timed out (is the worker alive?)"
+            )
+        rep = pickle.loads(sock.recv())
+        if not rep.get("ok"):
+            raise RuntimeError(
+                f"SGLang engine {handle.engine_idx} error: {rep.get('error')}\n"
+                f"{rep.get('traceback', '')}"
+            )
+        return handle.convert(rep) if handle.convert is not None else rep
+
+    def wait(self, handles: List[Handle]) -> list:
+        return [self._recv_one(h) for h in handles]
+
+    # -------------------------------------------------------------- async ops
+    @staticmethod
+    def _to_generation_outputs(rep) -> List[GenerationOutput]:
+        out = []
+        for o in rep["outputs"]:
+            comps = [Completion(text=c["text"], token_ids=c["token_ids"])
+                     for c in o["completions"]]
+            out.append(GenerationOutput(prompt=o["prompt"], outputs=comps))
+        return out
+
+    def generate_async(self, engine_idx, prompts, sampling: SamplingConfig) -> Handle:
+        return self._send(
+            engine_idx,
+            {"op": "generate", "prompts": list(prompts),
+             "sampling": {"n": sampling.n, "temperature": sampling.temperature,
+                          "top_p": sampling.top_p, "max_tokens": sampling.max_tokens}},
+            convert=self._to_generation_outputs,
+        )
+
+    def perturb_async(self, engine_idx, seed, sigma, negate=False) -> Handle:
+        return self._send(engine_idx,
+                          {"op": "perturb", "seed": int(seed), "sigma": float(sigma),
+                           "negate": bool(negate)})
+
+    def restore_async(self, engine_idx, seed, sigma) -> Handle:
+        return self._send(engine_idx, {"op": "restore", "seed": int(seed), "sigma": float(sigma)})
+
+    # --------------------------------------------------------- committed update
+    def sync_after_update(self, seeds, coeffs, alpha, population_size) -> None:
+        # Mirror the vLLM backend: apply the update on engine 0, then NCCL-broadcast
+        # its weights to every engine (one full-weight copy; no per-engine snapshot).
+        self.wait([
+            self._send(0, {"op": "apply_update",
+                           "seeds": [int(s) for s in seeds],
+                           "coeffs": [float(c) for c in coeffs],
+                           "alpha": float(alpha),
+                           "population_size": int(population_size)})
+        ])
+        if self._n_engines > 1:
+            # Broadcast is collective -- fire on all engines before waiting.
+            self.wait([
+                self._send(i, {"op": "broadcast_weights", "src": 0})
+                for i in range(self._n_engines)
+            ])
+
+    # --------------------------------------------------------------- checkpoint
+    def save(self, path: str, engine_idx: int = 0) -> None:
+        self.wait([self._send(engine_idx, {"op": "save", "path": path})])
+
+    def load(self, path: str) -> None:
+        self.wait([self._send(i, {"op": "load", "path": path})
+                   for i in range(self._n_engines)])
+
+    # ------------------------------------------------------------- drift check
+    def checksums(self):
+        reps = self.wait([self._send(i, {"op": "checksum"})
+                          for i in range(self._n_engines)])
+        return [tuple(r["checksum"]) for r in reps]

--- a/es_at_scale/backends/sglang_shim.py
+++ b/es_at_scale/backends/sglang_shim.py
@@ -1,0 +1,177 @@
+"""In-process SGLang shim that gives the ES trainer per-parameter weight ops on a
+live SGLang engine WITHOUT forking SGLang.
+
+SGLang's offline ``Engine`` spawns the model-owning ``Scheduler`` as a fresh
+(``spawn``) child process via ``mp.Process(target=run_scheduler_process)`` -- the
+module-level function referenced in ``sglang.srt.entrypoints.engine`` -- and exposes
+a generic ``collective_rpc(method, **kwargs)`` that runs ``getattr(scheduler,
+method)(**kwargs)`` on every TP rank + ``barrier()``.
+
+We replace ``engine.run_scheduler_process`` with a module-level wrapper (before
+constructing the Engine) that monkeypatches ``es_*`` methods onto ``Scheduler``
+*inside the spawned child*, then calls the real entrypoint. Those methods reach
+``self.tp_worker.model_runner.model.named_parameters()`` and run the shared
+:mod:`es_at_scale.backends.es_ops` math in place on the GPU. Only ints/floats/lists
+cross the RPC boundary -- noise is regenerated on-device from seeds.
+
+Weight logic mirrors the vLLM backend exactly: perturb in place, subtract-restore,
+apply the committed ES update on engine 0, then NCCL-broadcast engine-0's weights
+to every engine (one full-weight copy per iteration; no per-engine snapshot). The
+inter-engine group uses SGLang's own ``StatelessProcessGroup`` + ``PyNcclCommunicator``
+(a NCCL communicator independent of each engine's TP group), the same primitives
+vLLM uses.
+
+Verified against SGLang 0.5.6.post2. If those internals move, the worker's startup
+self-test (``es_selftest``) fails loudly rather than silently misbehaving.
+"""
+
+from __future__ import annotations
+
+import json
+
+import torch
+
+from es_at_scale.backends import es_ops
+
+
+def _params_fn(scheduler):
+    return lambda: scheduler.tp_worker.model_runner.model.named_parameters()
+
+
+# ---- Scheduler methods (run inside the spawned child, on each TP rank) ----
+
+def _es_perturb(self, seed, sigma, negate=False):
+    es_ops.perturb(_params_fn(self), seed, sigma, negate)
+
+
+def _es_restore(self, seed, sigma):
+    # Undo perturb by subtracting the same seeded noise (exact inverse up to
+    # bf16 rounding; the per-iteration engine-0 broadcast re-syncs any drift).
+    es_ops.restore_subtract(_params_fn(self), seed, sigma)
+
+
+def _es_apply_update(self, seeds, coeffs, alpha, population_size):
+    # Applied on engine 0 only; the result is then broadcast to every engine.
+    es_ops.apply_update(_params_fn(self), seeds, coeffs, alpha, population_size)
+
+
+def _es_save(self, path):
+    es_ops.save_to_disk(_params_fn(self), path)
+
+
+def _es_load(self, path):
+    pf = _params_fn(self)
+    device = next(pf())[1].device
+    es_ops.load_from_disk(pf, path, device)
+
+
+def _nccl_so_path():
+    # find_nccl_library() falls back to a bare "libnccl.so.2", which the dynamic
+    # linker cannot resolve when the lib lives at a pip path and LD_LIBRARY_PATH is
+    # unset. Point ctypes at the exact file instead.
+    try:
+        import os
+        import nvidia.nccl  # namespace package: use __path__, not __file__ (which is None)
+
+        base = list(nvidia.nccl.__path__)[0]
+        p = os.path.join(base, "lib", "libnccl.so.2")
+        return p if os.path.exists(p) else None
+    except Exception:
+        return None
+
+
+def _es_init_broadcast_group(self, master_address, master_port, rank, world_size):
+    # Inter-engine NCCL group: one rank per engine (TP=1). Independent of each
+    # engine's own TP group -- same StatelessProcessGroup/PyNccl pattern vLLM uses.
+    self._es_bcast = None
+    if int(world_size) <= 1:
+        return
+    from sglang.srt.distributed.utils import StatelessProcessGroup
+    from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+
+    so = _nccl_so_path()
+    device = next(self.tp_worker.model_runner.model.parameters()).device
+    pg = StatelessProcessGroup.create(
+        host=str(master_address), port=int(master_port),
+        rank=int(rank), world_size=int(world_size),
+    )
+    comm = PyNcclCommunicator(pg, device=device, library_path=so)
+    # `available` is False only if the NCCL library could not be loaded -- fail loudly
+    # (a dead broadcast would desync engines and corrupt training). Note the comm
+    # starts `disabled=True` by design; we enable it per-broadcast via change_state.
+    assert getattr(comm, "available", False), (
+        f"inter-engine NCCL communicator unavailable (nccl so={so!r})"
+    )
+    self._es_bcast = comm
+
+
+def _es_broadcast_weights(self, src_rank):
+    comm = getattr(self, "_es_bcast", None)
+    if comm is None:
+        return
+    with comm.change_state(enable=True):
+        for _, p in self.tp_worker.model_runner.model.named_parameters():
+            comm.broadcast(p.data, src=int(src_rank), stream=torch.cuda.current_stream())
+    torch.cuda.synchronize()
+
+
+def _es_checksum(self, out_path):
+    # collective_rpc returns only success/message, not values, so publish the
+    # checksum via a small file the worker reads back. TP rank 0 only.
+    if getattr(self, "tp_rank", 0) != 0:
+        return
+    sig = es_ops.checksum(_params_fn(self))
+    with open(out_path, "w") as f:
+        json.dump(list(sig), f)
+
+
+def _es_selftest(self, out_path):
+    # Assert the private weight path resolves and report the param count so the
+    # worker can cross-check it against the checkpoint.
+    if getattr(self, "tp_rank", 0) != 0:
+        return
+    names = [n for n, _ in _params_fn(self)()]
+    assert len(names) > 0, "model.named_parameters() is empty"
+    with open(out_path, "w") as f:
+        json.dump({"param_count": len(names)}, f)
+
+
+_ES_METHODS = {
+    "es_perturb": _es_perturb,
+    "es_restore": _es_restore,
+    "es_apply_update": _es_apply_update,
+    "es_save": _es_save,
+    "es_load": _es_load,
+    "es_init_broadcast_group": _es_init_broadcast_group,
+    "es_broadcast_weights": _es_broadcast_weights,
+    "es_checksum": _es_checksum,
+    "es_selftest": _es_selftest,
+}
+
+
+def _patch_scheduler_class():
+    from sglang.srt.managers.scheduler import Scheduler
+
+    for name, fn in _ES_METHODS.items():
+        setattr(Scheduler, name, fn)
+
+
+def run_scheduler_with_es(*args, **kwargs):
+    # Executed in the spawned child; patch BEFORE Scheduler(...) is constructed,
+    # then hand off to the real entrypoint.
+    _patch_scheduler_class()
+    from sglang.srt.managers.scheduler import run_scheduler_process
+
+    return run_scheduler_process(*args, **kwargs)
+
+
+def make_es_engine(**engine_kwargs):
+    """Construct an ``sglang.Engine`` whose scheduler child carries the ``es_*``
+    methods. The engine's ``_launch_subprocesses`` spawns the scheduler with
+    ``target=run_scheduler_process`` looked up in the engine module's namespace,
+    so replacing that name with our wrapper injects the patch."""
+    import sglang.srt.entrypoints.engine as _eng
+    from sglang.srt.entrypoints.engine import Engine
+
+    _eng.run_scheduler_process = run_scheduler_with_es
+    return Engine(**engine_kwargs)

--- a/es_at_scale/backends/sglang_worker.py
+++ b/es_at_scale/backends/sglang_worker.py
@@ -1,0 +1,193 @@
+"""SGLang ES worker: runs in the dedicated `sglang-es` conda env.
+
+Hosts one ``ESEngine`` (an ``sglang.Engine`` whose scheduler children carry the
+``es_*`` weight-op methods, see :mod:`es_at_scale.backends.sglang_shim`) and serves
+a ZeroMQ REP loop. The trainer-side :class:`~es_at_scale.backends.sglang_backend.SGLangBackend`
+drives it with tiny messages (seeds, sampling, prompts); weight noise never leaves
+the GPU. One worker == one engine == one GPU (TP=1 by default).
+
+Launched via ``python -m es_at_scale.backends.sglang_worker ...`` with
+``CUDA_VISIBLE_DEVICES`` pinned by the parent so the engine sees its GPU as cuda:0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import pickle
+import signal
+import sys
+import tempfile
+import traceback
+
+import zmq
+
+from es_at_scale.backends.sglang_shim import make_es_engine
+
+
+def _die_with_parent():
+    """Linux: receive SIGKILL if the parent (trainer) dies, so we never orphan a
+    GPU-holding worker. (SGLang's own kill-on-parent-death covers only the
+    scheduler child, not this REP-loop process.)"""
+    try:
+        PR_SET_PDEATHSIG = 1
+        ctypes.CDLL("libc.so.6").prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
+    except Exception:
+        pass
+
+
+def _reshape_generate(prompts, results):
+    if isinstance(results, dict):
+        results = [results]
+    outputs = []
+    for prompt, d in zip(prompts, results):
+        token_ids = d.get("output_ids")
+        comp = {"text": d.get("text", ""), "token_ids": list(token_ids or [])}
+        outputs.append({"prompt": prompt, "completions": [comp]})
+    return outputs
+
+
+def _handle(engine, msg):
+    op = msg["op"]
+    if op == "ping":
+        return {"ok": True}
+    if op == "perturb":
+        engine.collective_rpc(
+            "es_perturb", seed=int(msg["seed"]), sigma=float(msg["sigma"]),
+            negate=bool(msg.get("negate", False)),
+        )
+        return {"ok": True}
+    if op == "restore":
+        engine.collective_rpc("es_restore", seed=int(msg["seed"]), sigma=float(msg["sigma"]))
+        return {"ok": True}
+    if op == "apply_update":
+        engine.collective_rpc(
+            "es_apply_update", seeds=[int(s) for s in msg["seeds"]],
+            coeffs=[float(c) for c in msg["coeffs"]], alpha=float(msg["alpha"]),
+            population_size=int(msg["population_size"]),
+        )
+        return {"ok": True}
+    if op == "init_broadcast_group":
+        engine.collective_rpc(
+            "es_init_broadcast_group", master_address=msg["master_address"],
+            master_port=int(msg["master_port"]), rank=int(msg["rank"]),
+            world_size=int(msg["world_size"]),
+        )
+        return {"ok": True}
+    if op == "broadcast_weights":
+        engine.collective_rpc("es_broadcast_weights", src_rank=int(msg["src"]))
+        return {"ok": True}
+    if op == "generate":
+        s = msg["sampling"]
+        if int(s.get("n", 1)) != 1:
+            raise NotImplementedError("SGLang backend supports n=1 sampling only")
+        sp = {
+            "temperature": float(s["temperature"]),
+            "top_p": float(s["top_p"]),
+            "max_new_tokens": int(s["max_tokens"]),
+            "n": 1,
+        }
+        results = engine.generate(prompt=list(msg["prompts"]), sampling_params=sp)
+        return {"ok": True, "outputs": _reshape_generate(list(msg["prompts"]), results)}
+    if op == "checksum":
+        with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            engine.collective_rpc("es_checksum", out_path=path)
+            import json
+            with open(path) as fh:
+                sig = json.load(fh)
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        return {"ok": True, "checksum": sig}
+    if op == "save":
+        engine.collective_rpc("es_save", path=msg["path"])
+        return {"ok": True}
+    if op == "load":
+        engine.collective_rpc("es_load", path=msg["path"])
+        return {"ok": True}
+    raise ValueError(f"unknown op: {op}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--endpoint", required=True)
+    ap.add_argument("--tp-size", type=int, default=1)
+    ap.add_argument("--mem-fraction-static", type=float, default=0.7)
+    ap.add_argument("--dtype", default="bfloat16")
+    ap.add_argument("--random-seed", type=int, default=42)
+    ap.add_argument("--disable-cuda-graph", action="store_true")
+    args = ap.parse_args()
+
+    _die_with_parent()
+
+    engine = make_es_engine(
+        model_path=args.model,
+        tp_size=args.tp_size,
+        dp_size=1,
+        mem_fraction_static=args.mem_fraction_static,
+        dtype=args.dtype,
+        random_seed=args.random_seed,
+        skip_tokenizer_init=False,
+        disable_radix_cache=True,       # guardrail: no cross-request KV reuse under changing weights
+        disable_overlap_schedule=True,  # deterministic timing vs weight edits
+        disable_cuda_graph=args.disable_cuda_graph,
+        trust_remote_code=True,
+    )
+
+    def _shutdown(*_):
+        try:
+            engine.shutdown()
+        finally:
+            os._exit(0)
+
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    # Startup self-test: verify the shim reached the child and the weight path resolves.
+    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as f:
+        st_path = f.name
+    try:
+        engine.collective_rpc("es_selftest", out_path=st_path)
+        import json
+        with open(st_path) as fh:
+            info = json.load(fh)
+        print(f"[sglang_worker] self-test OK: param_count={info['param_count']}", flush=True)
+    finally:
+        try:
+            os.unlink(st_path)
+        except OSError:
+            pass
+
+    ctx = zmq.Context.instance()
+    sock = ctx.socket(zmq.REP)
+    sock.bind(args.endpoint)
+    print(f"[sglang_worker] ready on {args.endpoint}", flush=True)
+
+    while True:
+        raw = sock.recv()
+        msg = pickle.loads(raw)
+        if msg.get("op") == "shutdown":
+            sock.send(pickle.dumps({"ok": True}))
+            break
+        try:
+            reply = _handle(engine, msg)
+        except Exception as e:  # structured error -> trainer raises, never hangs
+            reply = {"ok": False, "error": f"{type(e).__name__}: {e}",
+                     "traceback": traceback.format_exc()}
+        reply["id"] = msg.get("id")
+        sock.send(pickle.dumps(reply))
+
+    try:
+        engine.shutdown()
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/es_at_scale/backends/vllm_backend.py
+++ b/es_at_scale/backends/vllm_backend.py
@@ -1,0 +1,237 @@
+"""vLLM implementation of :class:`ESBackend`.
+
+This is the original es-at-scale engine machinery moved behind the backend
+interface with its mechanism unchanged: N Ray-actor ``vllm.LLM`` engines, ES
+weight ops driven through ``collective_rpc`` into
+``es_at_scale.utils.worker_extension.WorkerExtension``, and the committed update
+applied on engine-0 then NCCL-broadcast to every engine.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import ray
+import torch
+from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from vllm import LLM, SamplingParams
+from vllm.utils import get_ip, get_open_port
+
+from es_at_scale.backends.base import (
+    Completion,
+    ESBackend,
+    GenerationOutput,
+    Handle,
+    SamplingConfig,
+)
+
+
+class ESNcclLLM(LLM):
+    def __init__(self, *args, **kwargs):
+        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+        super().__init__(*args, **kwargs)
+
+
+class _RayHandle:
+    """Wraps a Ray ``ObjectRef`` plus an optional post-``ray.get`` converter so
+    ``wait`` can uniformly resolve weight-op handles (result ignored) and
+    generation handles (converted to ``List[GenerationOutput]``)."""
+
+    __slots__ = ("ref", "convert")
+
+    def __init__(self, ref, convert=None):
+        self.ref = ref
+        self.convert = convert
+
+
+class VLLMBackend(ESBackend):
+    def __init__(
+        self,
+        model_name: str,
+        n_engines: int,
+        n_gpu_per_engine: int = 1,
+        dtype: str = "bfloat16",
+        gpu_memory_utilization: float = 0.7,
+        seed=None,
+        use_gpus: str = None,
+    ):
+        self.model_name = model_name
+        self._n_engines = int(n_engines)
+        self.n_gpu_per_engine = int(n_gpu_per_engine)
+        self.dtype = dtype
+        self.gpu_memory_utilization = gpu_memory_utilization
+        self.seed = seed
+        self.use_gpus = use_gpus
+        self.engines = []
+        self.pgs = []
+
+    @property
+    def num_engines(self) -> int:
+        return self._n_engines
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        if self.use_gpus is not None:
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.use_gpus
+        os.environ.pop("RAY_ADDRESS", None)
+        os.environ.pop("RAY_HEAD_IP", None)
+        os.environ.pop("RAY_GCS_SERVER_ADDRESS", None)
+        ray.init(address="local", include_dashboard=False, ignore_reinit_error=True)
+
+        self.engines, self.pgs = self._launch_engines()
+
+        master_address = get_ip()
+        master_port = get_open_port()
+        ray.get(
+            [
+                self.engines[i].collective_rpc.remote(
+                    "init_inter_engine_group",
+                    args=(master_address, master_port, i, self._n_engines),
+                )
+                for i in range(self._n_engines)
+            ]
+        )
+
+    def _launch_engines(self):
+        pgs = [
+            placement_group(
+                [{"GPU": 1, "CPU": 0}] * self.n_gpu_per_engine,
+                strategy="PACK",
+                lifetime="detached",
+            )
+            for _ in range(self._n_engines)
+        ]
+        ray.get([pg.ready() for pg in pgs])
+
+        strategies = [
+            PlacementGroupSchedulingStrategy(
+                placement_group=pg,
+                placement_group_capture_child_tasks=True,
+                placement_group_bundle_index=0,
+            )
+            for pg in pgs
+        ]
+
+        engines = [
+            ray.remote(num_cpus=0, num_gpus=0, scheduling_strategy=strategy)(
+                ESNcclLLM
+            ).remote(
+                model=self.model_name,
+                tensor_parallel_size=self.n_gpu_per_engine,
+                distributed_executor_backend="ray",
+                worker_extension_cls="es_at_scale.utils.worker_extension.WorkerExtension",
+                dtype=self.dtype,
+                enable_prefix_caching=False,
+                enforce_eager=False,
+                gpu_memory_utilization=self.gpu_memory_utilization,
+            )
+            for strategy in strategies
+        ]
+        return engines, pgs
+
+    def shutdown(self) -> None:
+        for llm in self.engines:
+            try:
+                ray.kill(llm)
+            except Exception:
+                pass
+        for pg in self.pgs:
+            try:
+                remove_placement_group(pg)
+            except Exception:
+                pass
+        self.engines = []
+        self.pgs = []
+
+    # -------------------------------------------------------------- async ops
+    def _sampling_params(self, sampling: SamplingConfig) -> SamplingParams:
+        return SamplingParams(
+            n=sampling.n,
+            seed=sampling.seed,
+            temperature=sampling.temperature,
+            top_p=sampling.top_p,
+            max_tokens=sampling.max_tokens,
+        )
+
+    @staticmethod
+    def _to_generation_outputs(request_outputs) -> List[GenerationOutput]:
+        out = []
+        for ro in request_outputs:
+            comps = [
+                Completion(text=o.text, token_ids=list(o.token_ids))
+                for o in ro.outputs
+            ]
+            out.append(GenerationOutput(prompt=ro.prompt, outputs=comps))
+        return out
+
+    def generate_async(
+        self, engine_idx: int, prompts: List[str], sampling: SamplingConfig
+    ) -> Handle:
+        ref = self.engines[engine_idx].generate.remote(
+            prompts, self._sampling_params(sampling), use_tqdm=False
+        )
+        return _RayHandle(ref, convert=self._to_generation_outputs)
+
+    def perturb_async(
+        self, engine_idx: int, seed: int, sigma: float, negate: bool = False
+    ) -> Handle:
+        ref = self.engines[engine_idx].collective_rpc.remote(
+            "perturb_self_weights", args=(int(seed), sigma, negate)
+        )
+        return _RayHandle(ref)
+
+    def restore_async(self, engine_idx: int, seed: int, sigma: float) -> Handle:
+        ref = self.engines[engine_idx].collective_rpc.remote(
+            "restore_self_weights", args=(int(seed), sigma)
+        )
+        return _RayHandle(ref)
+
+    def wait(self, handles: List[Handle]) -> list:
+        results = ray.get([h.ref for h in handles])
+        return [
+            h.convert(r) if h.convert is not None else r
+            for h, r in zip(handles, results)
+        ]
+
+    # --------------------------------------------------------- committed update
+    def sync_after_update(
+        self, seeds, coeffs, alpha: float, population_size: int
+    ) -> None:
+        ray.get(
+            self.engines[0].collective_rpc.remote(
+                "update_weights_from_seeds",
+                args=(seeds, coeffs, alpha, population_size),
+            )
+        )
+        ray.get(
+            [
+                e.collective_rpc.remote("broadcast_all_weights", args=(0,))
+                for e in self.engines
+            ]
+        )
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+    # --------------------------------------------------------------- checkpoint
+    def save(self, path: str, engine_idx: int = 0) -> None:
+        ray.get(
+            self.engines[engine_idx].collective_rpc.remote(
+                "save_self_weights_to_disk", args=(path,)
+            )
+        )
+
+    def load(self, path: str) -> None:
+        ray.get(
+            [
+                e.collective_rpc.remote("load_weights_from_disk", args=(path,))
+                for e in self.engines
+            ]
+        )
+
+    # ------------------------------------------------------------- drift check
+    def checksums(self):
+        # collective_rpc returns one result per TP worker; TP=1 -> take [0].
+        refs = [e.collective_rpc.remote("es_checksum") for e in self.engines]
+        return [tuple(res[0]) for res in ray.get(refs)]

--- a/es_at_scale/train.py
+++ b/es_at_scale/train.py
@@ -81,6 +81,14 @@ def main():
                         help="Experiment name for logging and checkpoints. Auto-generated from hyperparams if not set.")
     parser.add_argument("--wandb-project", type=str, default="es-finetuning")
 
+    parser.add_argument("--backend", type=str, default="vllm", choices=["vllm", "sglang"],
+                        help="Inference backend for rollouts and ES weight ops.")
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.7,
+                        help="vLLM gpu_memory_utilization / SGLang mem_fraction_static.")
+    parser.add_argument("--sglang-python", type=str, default=None,
+                        help="Path to the SGLang env python (else $ES_SGLANG_PYTHON); only for --backend sglang.")
+
     args = parser.parse_args()
     print(args)
 
@@ -139,7 +147,35 @@ def main():
 
     print(f"-- Running: {experiment_name} --")
 
+    from es_at_scale.backends import get_backend
+
+    if args.backend == "vllm":
+        backend = get_backend(
+            "vllm",
+            model_name=args.model_name,
+            n_engines=args.n_vllm_engines,
+            n_gpu_per_engine=args.n_gpu_per_vllm_engine,
+            dtype=args.dtype,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            seed=args.seed,
+            use_gpus=args.use_gpus,
+        )
+    else:
+        gpu_ids = [int(x) for x in args.use_gpus.split(",") if x != ""]
+        backend = get_backend(
+            "sglang",
+            model_name=args.model_name,
+            n_engines=args.n_vllm_engines,
+            gpus=gpu_ids,
+            n_gpu_per_engine=args.n_gpu_per_vllm_engine,
+            dtype=args.dtype,
+            mem_fraction_static=args.gpu_memory_utilization,
+            seed=args.seed,
+            sglang_python=args.sglang_python,
+        )
+
     trainer = EvolutionStrategiesTrainer(
+        backend=backend,
         model_name=args.model_name,
         checkpoint=args.checkpoint,
         sigma=args.sigma,
@@ -155,18 +191,13 @@ def main():
         train_dataloader=train_dataloader,
         eval_dataloader_dict=eval_dataloader_dict,
         eval_freq=args.eval_freq,
-        n_vllm_engines=args.n_vllm_engines,
-        n_gpu_per_vllm_engine=args.n_gpu_per_vllm_engine,
         logging=args.logging,
         global_seed=args.seed,
-        use_gpus=args.use_gpus,
         experiment_name=experiment_name,
         wandb_project=args.wandb_project,
         save_best_models=args.save_best_models,
         reward_function_timeout=args.reward_function_timeout,
-        output_directory=args.output_directory
-        
-
+        output_directory=args.output_directory,
     )
 
     trainer.fit()

--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -7,36 +7,21 @@ import sys
 import time
 import numpy as np
 
-import ray
-from ray.util.placement_group import placement_group, remove_placement_group
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-
-from vllm import LLM, SamplingParams
-from vllm.utils import get_ip, get_open_port
-from transformers import AutoTokenizer
-
-
 import torch
 import json
 
-from typing import List
 from multiprocessing import Pool, TimeoutError
 import functools
 
+from es_at_scale.backends import SamplingConfig
 from es_at_scale.utils.reward_shaping import z_score
-
-
-class ESNcclLLM(LLM):
-    def __init__(self, *args, **kwargs):
-        #os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
-        super().__init__(*args, **kwargs)
 
 
 class EvolutionStrategiesTrainer:
     def __init__(
         self,
-        model_name,           # HuggingFace model ID or local path, e.g. "Qwen/Qwen2.5-Math-7B"
+        backend,              # An ESBackend instance (vLLM/SGLang/...). Owns the inference engines.
+        model_name,           # HuggingFace model ID or local path; used here only for the tokenizer.
         checkpoint,           # Path to a .pth ES checkpoint to resume from, or None to start fresh
         sigma,                # Noise scale: std dev of Gaussian perturbations applied to weights
         alpha,                # Learning rate: controls how far we move in the estimated gradient direction
@@ -51,10 +36,7 @@ class EvolutionStrategiesTrainer:
         train_dataloader,     # PyTorch DataLoader yielding (list[prompt], list[target]) batches
         eval_dataloader_dict, # Dict[task_name, DataLoader] of evaluation sets; all are run at eval_freq
         eval_freq,            # Run evaluation every this many training iterations
-        n_vllm_engines,       # Number of vLLM engine actors to launch (one per GPU is typical)
-        n_gpu_per_vllm_engine,# GPUs assigned to each vLLM engine (use >1 for tensor-parallel large models)
         logging,              # Logging backend: "wandb" to enable W&B tracking, or "none"
-        use_gpus,             # Comma-separated GPU indices visible to this process, e.g. "0,1,2,3"
         global_seed=None,     # Master random seed for reproducible perturbation sequences
         output_directory=None,# Root directory for experiment outputs (checkpoints, eval logs)
         save_best_models=True,# If True, save a checkpoint whenever a new best eval score is achieved, final model is always saved to disk upon training completion
@@ -63,14 +45,7 @@ class EvolutionStrategiesTrainer:
         reward_function_timeout=60  # Seconds before a reward function call is killed and assigned 0.0
 
     ):
-        # GPU init
-        os.environ["CUDA_VISIBLE_DEVICES"] = use_gpus
-        # Ray init
-        os.environ.pop("RAY_ADDRESS", None)
-        os.environ.pop("RAY_HEAD_IP", None)
-        os.environ.pop("RAY_GCS_SERVER_ADDRESS", None)
-
-        ray.init(address="local", include_dashboard=False, ignore_reinit_error=True)
+        self.backend = backend
 
         signal.signal(signal.SIGINT, lambda sig, frame: self._handle_exit(sig, frame))
         signal.signal(signal.SIGTERM, lambda sig, frame: self._handle_exit(sig, frame))
@@ -86,8 +61,6 @@ class EvolutionStrategiesTrainer:
         self.max_tokens = max_tokens
         self.batch_size = batch_size
         self.mini_batch_size = mini_batch_size
-        self.n_vllm_engines = n_vllm_engines
-        self.n_gpu_per_vllm_engine = n_gpu_per_vllm_engine
         self.eval_freq = eval_freq
         self.logging = logging
         self.global_seed = global_seed
@@ -153,40 +126,16 @@ class EvolutionStrategiesTrainer:
             self.wandb.define_metric("train/*", step_metric="global_step")
             self.wandb.define_metric("eval/*", step_metric="global_step")
 
+        from transformers import AutoTokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self.best_member = -np.inf
 
-        torch.cuda.empty_cache()
-        gc.collect()
+        # Start persistent engines (backend owns GPU placement and weight ops).
+        self.backend.start()
 
-        # Start persistent engines
-        self.engines, self.pgs = self.launch_engines(
-            num_engines=self.n_vllm_engines, 
-            n_gpu_per_vllm_engine=self.n_gpu_per_vllm_engine, 
-            model_name=self.model_name
-        )
-
-        master_address = get_ip()
-        master_port = get_open_port()
-        ray.get(
-            [
-                self.engines[i].collective_rpc.remote(
-                    "init_inter_engine_group",
-                    args=(master_address, master_port, i, self.n_vllm_engines),
-                )
-                for i in range(self.n_vllm_engines)
-            ]
-        )
         if self.checkpoint is not None:
             print("Loading checkpoint weights")
-            ray.get(
-                [
-                    self.engines[i].collective_rpc.remote(
-                        "load_weights_from_disk", args=(self.checkpoint,)
-                    )
-                    for i in range(self.n_vllm_engines)
-                ]
-            )
+            self.backend.load(self.checkpoint)
             print("Completed loading checkpoint weights")
 
         self.eval_cache = {}  # name -> (prompts, targets)
@@ -199,17 +148,11 @@ class EvolutionStrategiesTrainer:
                 break
 
     def cleanup(self):
-        """Gracefully terminate all Ray actors and placement groups."""
-        for llm in self.engines:
-            try:
-                ray.kill(llm)
-            except Exception:
-                pass
-        for pg in self.pgs:
-            try:
-                remove_placement_group(pg)
-            except Exception:
-                pass
+        """Gracefully terminate all engines owned by the backend."""
+        try:
+            self.backend.shutdown()
+        except Exception:
+            pass
         print("[INFO] Cleanup complete.")
 
     def _handle_exit(self, sig, frame):
@@ -217,45 +160,6 @@ class EvolutionStrategiesTrainer:
         print(f"[INFO] Received signal {sig}, cleaning up...")
         self.cleanup()
         sys.exit(0)
-
-    def launch_engines(
-        self, num_engines=4, n_gpu_per_vllm_engine=1, model_name="Qwen/Qwen2.5-Math-1.5B", precision="bfloat16"
-    ):
-        pgs = [
-            placement_group(
-                [{"GPU": 1, "CPU": 0}] * n_gpu_per_vllm_engine, 
-                strategy="PACK",
-                lifetime="detached")
-            for _ in range(num_engines)
-        ]
-        ray.get([pg.ready() for pg in pgs])
-
-        strategies = [
-            PlacementGroupSchedulingStrategy(
-                placement_group=pg,
-                placement_group_capture_child_tasks=True,
-                placement_group_bundle_index=0,
-            )
-            for pg in pgs
-        ]
-
-        engines = [
-            ray.remote(num_cpus=0, num_gpus=0, scheduling_strategy=strategy)(
-                ESNcclLLM
-            ).remote(
-                model=model_name,
-                tensor_parallel_size=n_gpu_per_vllm_engine,
-                distributed_executor_backend="ray",
-                worker_extension_cls="es_at_scale.utils.worker_extension.WorkerExtension",
-                dtype=precision,
-                enable_prefix_caching=False,
-                enforce_eager=False,
-                gpu_memory_utilization=0.7,
-            )
-            for strategy in strategies
-        ]
-        return engines, pgs
-
 
     def _postprocess_outputs(self, generated_text, target_text, eval=False):
         rewards_per_prompt, gen_lens_per_prompt, save, raw_rewards_per_prompt, raw_lens_per_prompt, = [], [], [], [], []
@@ -278,6 +182,7 @@ class EvolutionStrategiesTrainer:
                     fmt, r = res.get(timeout=self.reward_function_timeout)
                     rollout_rewards.append(float(r))
                 except TimeoutError:
+                    fmt, r = None, 0.0
                     rollout_rewards.append(0.0)
 
                 rollout_lens.append(int(gen_len))
@@ -323,12 +228,10 @@ class EvolutionStrategiesTrainer:
             "n_samples": int(self.n_samples),
         }
 
-
     def train_step(self, iteration, seeds, input_text, target_text):
 
-        sampling_params = SamplingParams(
+        sampling = SamplingConfig(
             n=self.n_samples,
-            # sampling seed tied to iteration
             seed=(self.global_seed or 42) + iteration,
             temperature=self.train_temperature,
             top_p=self.train_top_p,
@@ -360,7 +263,7 @@ class EvolutionStrategiesTrainer:
                 seeds,
                 input_batch,
                 target_batch,
-                sampling_params,
+                sampling,
             )
 
             all_results_this_gen.extend(results_this_gen)
@@ -427,25 +330,10 @@ class EvolutionStrategiesTrainer:
             for seed in seeds
         ]
 
-        ray.get(
-            self.engines[0].collective_rpc.remote(
-                "update_weights_from_seeds",
-                args=(
-                    seeds,
-                    coeffs,
-                    self.alpha,
-                    self.population_size,
-                ),
-            )
+        # Commit the ES update and leave every engine at the identical new theta.
+        self.backend.sync_after_update(
+            seeds, coeffs, self.alpha, self.population_size
         )
-
-        ray.get(
-            [
-                e.collective_rpc.remote("broadcast_all_weights", args=(0,))
-                for e in self.engines
-            ]
-        )
-        torch.cuda.synchronize()
 
     def _iter_minibatches(self, input_text, target_text, mini_batch_size: int):
         n = len(input_text)
@@ -453,39 +341,36 @@ class EvolutionStrategiesTrainer:
             end = start + mini_batch_size
             yield input_text[start:end], target_text[start:end]
 
-    def evaluate_handle(self, llm, input_text, sampling_params):
-        handle = llm.generate.remote(input_text, sampling_params, use_tqdm=False)
-        return handle
-
     def evaluate_population_on_batch(
         self,
         seeds,
         input_batch,
         target_batch,
-        sampling_params,
+        sampling,
     ):
         seeds_perf_batch = {}
         results_this_gen = []
 
+        n_engines = self.backend.num_engines
         # Static batching -- issue exactly one seed per engine per batch in fixed order, then wait
-        for b in range(0, len(seeds), self.n_vllm_engines):
-            engine_batch = seeds[b:b+self.n_vllm_engines]
+        for b in range(0, len(seeds), n_engines):
+            engine_batch = seeds[b:b + n_engines]
             # 1) Perturb the model weights
-            ray.get([
-                self.engines[eng_idx].collective_rpc.remote("perturb_self_weights", args=(int(seed), self.sigma, False))
+            self.backend.wait([
+                self.backend.perturb_async(eng_idx, int(seed), self.sigma)
                 for eng_idx, seed in enumerate(engine_batch)
             ])
 
             # 2) Generate with fixed generation seed tied to the current iteration
-            handles = [
-                self.evaluate_handle(self.engines[eng_idx], input_batch, sampling_params=sampling_params)
-                for eng_idx, _ in enumerate(engine_batch)
+            gen_handles = [
+                self.backend.generate_async(eng_idx, input_batch, sampling)
+                for eng_idx in range(len(engine_batch))
             ]
             # 3) Collect outputs in the same order
-            outputs_per_engine = ray.get(handles)
+            outputs_per_engine = self.backend.wait(gen_handles)
             # 4) Restore weights
-            ray.get([
-                self.engines[eng_idx].collective_rpc.remote("restore_self_weights", args=(int(seed), self.sigma))
+            self.backend.wait([
+                self.backend.restore_async(eng_idx, int(seed), self.sigma)
                 for eng_idx, seed in enumerate(engine_batch)
             ])
             # 5) Score and record
@@ -500,12 +385,11 @@ class EvolutionStrategiesTrainer:
                         }
                     )
 
-        return seeds_perf_batch, results_this_gen        
+        return seeds_perf_batch, results_this_gen
 
     def eval_step(self, iteration):
         to_log = {"eval-iteration": iteration}
         mean_eval_results = []
-        llm = self.engines[0]
 
         for name, eval_loader in self.eval_dataloader_dict.items():
             # Accumulate per-prompt reward sum and prompt count so the dataset
@@ -518,7 +402,7 @@ class EvolutionStrategiesTrainer:
             for input_text, target_text in eval_loader:
                 input_text = [self.template(i) for i in input_text]
 
-                sampling_params = SamplingParams(
+                sampling = SamplingConfig(
                     n=1,
                     seed=(self.global_seed or 42) + iteration,
                     temperature=0.0,
@@ -526,13 +410,9 @@ class EvolutionStrategiesTrainer:
                     max_tokens=self.max_tokens,
                 )
 
-                outputs = ray.get(
-                                    llm.generate.remote(
-                                        input_text,
-                                        sampling_params,
-                                        use_tqdm=False
-                                    )
-                                )
+                outputs = self.backend.wait(
+                    [self.backend.generate_async(0, input_text, sampling)]
+                )[0]
 
                 metrics = self._postprocess_outputs(outputs, target_text, eval=True)
 
@@ -574,12 +454,7 @@ class EvolutionStrategiesTrainer:
                     f"{self.logging_dir}/checkpoints/{self.experiment_name}-mean{float(np.mean(mean_eval_results))}"
                 )
                 os.makedirs(model_path, exist_ok=True)
-                ray.get(
-                    self.engines[0].collective_rpc.remote(
-                        "save_self_weights_to_disk",
-                        args=(f"{model_path}/pytorch_model.pth",),
-                    )
-                )
+                self.backend.save(f"{model_path}/pytorch_model.pth")
 
     def fit(self):
         iteration, epoch = 0, 0
@@ -604,7 +479,7 @@ class EvolutionStrategiesTrainer:
             for input_text, target_text in self.train_dataloader:
                 input_text = [self.template(i) for i in input_text]
                 print(f"\n\n=== Epoch {epoch+1}; Iteration {iteration+1} ===")
-                total_iter_start = time.time()                
+                total_iter_start = time.time()
 
                 # Deterministic per-iteration seed list
                 loop_rng = np.random.default_rng(seed=(self.global_seed or 42) + iteration)
@@ -629,19 +504,14 @@ class EvolutionStrategiesTrainer:
                 if iteration > self.num_iterations:
                     done = True
                     break
-            
+
             epoch += 1
             if done:
                 break
 
         final_model_path = f"{self.logging_dir}/checkpoint-es_fine_tuned_iteration_{self.num_iterations}"
         os.makedirs(final_model_path, exist_ok=True)
-        ray.get(
-            self.engines[0].collective_rpc.remote(
-                "save_self_weights_to_disk",
-                args=(f"{final_model_path}/pytorch_model.pth",),
-            )
-        )
+        self.backend.save(f"{final_model_path}/pytorch_model.pth")
         print(f"Final model weights saved to {final_model_path}.")
 
         self.cleanup()

--- a/es_at_scale/utils/worker_extension.py
+++ b/es_at_scale/utils/worker_extension.py
@@ -1,8 +1,9 @@
-import gc
-import time
-import torch
 import random
+
 import numpy as np
+import torch
+
+from es_at_scale.backends import es_ops
 
 
 def _stateless_init_process_group(
@@ -12,18 +13,27 @@ def _stateless_init_process_group(
     from vllm.distributed.utils import StatelessProcessGroup
 
     pg = StatelessProcessGroup.create(
-        host=master_address, 
-        port=master_port, 
-        rank=rank, 
+        host=master_address,
+        port=master_port,
+        rank=rank,
         world_size=world_size
     )
     return PyNcclCommunicator(pg, device=device)
 
 
 class WorkerExtension:
+    """The class for vLLM's worker to inherit from.
+
+    The ES weight math lives in the backend-agnostic ``es_at_scale.backends.es_ops``
+    module; the methods below are thin vLLM-specific adapters that (a) supply the
+    ``model_runner.model.named_parameters()`` accessor and (b) own the inter-engine
+    PyNccl group used to broadcast engine-0's weights to every engine. Method
+    signatures are kept identical to the pre-refactor version so the trainer's
+    ``collective_rpc(...)`` call sites are unchanged.
     """
-    The class for vLLM's worker to inherit from.
-    """
+
+    def _params(self):
+        return self.model_runner.model.named_parameters()
 
     def _set_seed(self, seed):
         # set a seed locally on the worker extension for reproducibility
@@ -35,30 +45,16 @@ class WorkerExtension:
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)
 
-    def save_self_initial_weights(
-        self,
-    ):
-        """Save a copy of itself in the CPU memory."""
-        self.initial_weights = {}
-        for name, p in self.model_runner.model.named_parameters():
-            self.initial_weights[name] = p.detach().clone().cpu()
+    def save_self_initial_weights(self):
+        """Save a copy of itself in CPU memory."""
+        self.initial_weights = es_ops.snapshot(self._params, device="cpu")
         print("Initial weights saved.")
-
 
     def restore_self_weights(self, seed, sigma):
         self._set_seed(seed)
-        for _, p in self.model_runner.model.named_parameters():
-            gen = torch.Generator(device=p.device)
-            gen.manual_seed(int(seed))
-            noise = torch.randn(p.shape, dtype=p.dtype, device=p.device, generator=gen)
-            p.data.add_(-float(sigma) * noise)
-            del noise
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        torch.cuda.empty_cache()
+        es_ops.restore_subtract(self._params, seed, sigma)
         return True
 
-    
     def init_inter_engine_group(self, master_address: str, master_port: int,
                             engine_idx: int, num_engines: int):
             # TP rank within the engine (0..tp_size-1)
@@ -84,9 +80,9 @@ class WorkerExtension:
                 device=self.device,
             )
             return True
-    
+
     def broadcast_all_weights(self, src_rank: int):
-        for _, p in self.model_runner.model.named_parameters():
+        for _, p in self._params():
             self.inter_pg.broadcast(
                 p, src=int(src_rank), stream=torch.cuda.current_stream()
             )
@@ -95,85 +91,22 @@ class WorkerExtension:
         return True
 
     def update_weights_from_seeds(self, seeds, coeffs, alpha, population_size):
-        """
-        Mimics the Original implementation's update loop structure:
-        Iterate Param -> Iterate Seeds -> Accumulate -> Single Update.
-        """
-        # seeds and coeffs should be lists of equal length
-        # coeffs[i] should be: (alpha / population_size) * normalized_reward
-
-        for _, p in self.model_runner.model.named_parameters():
-            # float32
-            update_accumulator = torch.zeros_like(p.data, dtype=torch.float32)
-
-            for i, (seed) in enumerate(seeds):
-                gen = torch.Generator(device=p.device)
-                gen.manual_seed(int(seed))
-
-                # Generate noise (in native precision, usually float16/bfloat16)
-                noise = torch.randn(
-                    p.shape, dtype=p.dtype, device=p.device, generator=gen
-                )
-
-                # FIXED: Convert noise to float32 BEFORE multiplication.
-                # Previous code: noise.to(torch.float16) * coeffs[i]
-                # This caused the tiny update signal (1e-5) to be truncated by FP16 precision limits.
-                term = noise.to(torch.float32) * coeffs[i]
-
-                # Accumulate in FP32
-                update_accumulator.add_(term)
-
-            # multiply with scale (alpha/population_size) once at the end to preserve precision
-            scale = float(alpha) / float(population_size)
-            update_accumulator.mul_(scale)
-            # Apply final update to weight (cast back to model dtype at the very end)
-            p.data.add_(update_accumulator.to(p.dtype))
-
-            del update_accumulator
-
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        torch.cuda.empty_cache()
+        es_ops.apply_update(self._params, seeds, coeffs, alpha, population_size)
         return True
 
+    def es_checksum(self):
+        return es_ops.checksum(self._params)
+
     def perturb_self_weights(self, seed, noise_scale, negate=False):
-        """
-        Add noise(seed) scaled by sigma_or_scale * coeff (or subtract when negate=True).
-        - For exploration:  perturb_self_weights(seed, SIGMA, 1.0, False)
-          and restore with restore_self_weights(seed, SIGMA) as before.
-        - For ES update:   perturb_self_weights(seed, 1.0, coeff, False)
-          where coeff = ALPHA/POPULATION_SIZE * norm_reward.
-        """
         self._set_seed(seed)
-        scale = float(noise_scale)
-        sign = -1.0 if negate else 1.0
-
-        for _, p in self.model_runner.model.named_parameters():
-            gen = torch.Generator(device=p.device)
-            gen.manual_seed(int(seed))
-            noise = torch.randn(p.shape, dtype=p.dtype, device=p.device, generator=gen)
-            p.data.add_(sign * scale * noise)
-            del noise
-
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        torch.cuda.empty_cache()
-        print(f"Weights changed with: sign={sign}; scale={sign * scale}.")
+        es_ops.perturb(self._params, seed, noise_scale, negate)
+        print(f"Weights changed with: negate={negate}; scale={noise_scale}.")
 
     def save_self_weights_to_disk(self, filepath):
         """Save the current model weights to disk."""
-        state_dict_to_save = {}
-        for name, p in self.model_runner.model.named_parameters():
-            state_dict_to_save[name] = p.detach().cpu()
-        torch.save(state_dict_to_save, filepath)
+        es_ops.save_to_disk(self._params, filepath)
         print(f"Model weights saved to {filepath}.")
 
     def load_weights_from_disk(self, filepath):
-        state_dict = torch.load(filepath, map_location=self.device)
-        for name, p in self.model_runner.model.named_parameters():
-            p.data.copy_(state_dict[name].to(self.device))
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        time.sleep(0.1)
+        es_ops.load_from_disk(self._params, filepath, self.device)
         return True

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,25 @@
-from setuptools import setup
-import os
-from setuptools import dist
+from setuptools import find_packages, setup
 
+# Core is intentionally backend-agnostic and vLLM-free so it can be installed
+# into the SGLang worker's conda env (which must not pull in vllm). Backend
+# engines come from extras:
+#   pip install -e ".[vllm]"     # trainer + vLLM engines (es-prefix-cache env)
+#   pip install -e ".[sglang]"   # SGLang worker (sglang-es env); sglang installed separately
 required = [
     "numpy",
     "torch>=2.0.0",
-    "transformers==4.57.6",
-    "vllm==0.11.0",
-    "accelerate>=0.20.0",
-    "matplotlib>=3.5.0",
+    "transformers",  # exact version is a per-backend concern (see extras) -- do NOT pin in core:
+                     # vLLM 0.11 wants 4.57.6, SGLang 0.5.6.post2 wants 4.57.1.
     "psutil",
-    "futures",
-    # "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiTRUE-cp310-cp310-linux_x86_64.whl",
-    "black==22.8.0",
-    "flake8==5.0.4",
     "datasets",
+    "matplotlib>=3.5.0",
 ]
+
+extras = {
+    "vllm": ["vllm==0.11.0", "transformers==4.57.6", "ray", "accelerate>=0.20.0"],
+    "sglang": ["pyzmq"],  # the sglang wheel (which pins transformers==4.57.1) is installed separately in its env
+    "dev": ["black==22.8.0", "flake8==5.0.4"],
+}
 
 
 setup(
@@ -23,6 +27,7 @@ setup(
     version="0.0.1",
     description="Python code to fine-tune LLMs with Evolution Strategies.",
     author="Cognizant AI Lab",
-    packages=["es_at_scale"],
+    packages=find_packages(include=["es_at_scale", "es_at_scale.*"]),
     install_requires=required,
+    extras_require=extras,
 )

--- a/tests/e2e/test_backend.py
+++ b/tests/e2e/test_backend.py
@@ -1,0 +1,116 @@
+"""End-to-end backend integration test (real engines, real GPUs).
+
+Exercises the full ESBackend contract against a live engine and validates the
+correctness guardrails that matter for ES:
+  * generate works and is deterministic (greedy);
+  * perturb changes weights, restore returns EXACTLY to baseline output
+    (this is also the radix-cache-off regression: stale KV would break it);
+  * all engines are bit-identical at start and STAY identical after a committed
+    ES update (validates the engine-0-update + NCCL broadcast on real GPUs);
+  * save -> perturb -> load round-trips back to a consistent state.
+
+Run (from repo root, in the matching env):
+  vLLM  :  python tests/e2e/test_backend.py --backend vllm   --gpus 4,5
+  SGLang:  ES_SGLANG_PYTHON=/path/to/sglang-es/python \
+           python tests/e2e/test_backend.py --backend sglang --gpus 6,7
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+
+from es_at_scale.backends import SamplingConfig, get_backend
+
+PROMPT = ["The capital of France is"]
+
+
+def build(backend, model, gpus):
+    if backend == "vllm":
+        return get_backend(
+            "vllm", model_name=model, n_engines=len(gpus),
+            n_gpu_per_engine=1, use_gpus=",".join(str(g) for g in gpus),
+        )
+    return get_backend(
+        "sglang", model_name=model, n_engines=len(gpus), gpus=gpus,
+        n_gpu_per_engine=1,
+    )
+
+
+def gen_text(b, engine_idx, sampling):
+    out = b.wait([b.generate_async(engine_idx, PROMPT, sampling)])[0][0]
+    return out.outputs[0].text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backend", choices=["vllm", "sglang"], required=True)
+    ap.add_argument("--model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    ap.add_argument("--gpus", default="4,5")
+    args = ap.parse_args()
+    gpus = [int(x) for x in args.gpus.split(",") if x != ""]
+
+    sampling = SamplingConfig(n=1, temperature=0.0, top_p=1.0, max_tokens=32, seed=0)
+    b = build(args.backend, args.model, gpus)
+    b.start()
+    try:
+        # 1) engines bit-identical right after load, BEFORE any perturbation.
+        #    (After a bare perturb/restore, vLLM's subtract-restore leaves tiny
+        #    bf16 drift on the touched engine until the next update re-broadcasts;
+        #    that transient is expected, so we check identity here and post-update.)
+        cks0 = b.checksums()
+        if all(c is not None for c in cks0):
+            assert len(set(cks0)) == 1, f"engines differ after load: {cks0}"
+            print(f"[ok] {len(cks0)} engines bit-identical after load")
+
+        # 2) baseline greedy generation on engine 0
+        base_text = gen_text(b, 0, sampling)
+        print(f"[info] baseline: {base_text!r}")
+
+        # 3) perturb -> (informational) generation may change
+        b.wait([b.perturb_async(0, 12345, 0.01)])
+        pert_text = gen_text(b, 0, sampling)
+        print(f"[info] perturbed: {pert_text!r} (changed={pert_text != base_text})")
+
+        # 4) restore -> MUST return exactly to baseline output
+        b.wait([b.restore_async(0, 12345, 0.01)])
+        rest_text = gen_text(b, 0, sampling)
+        assert rest_text == base_text, (
+            f"restore did not reproduce baseline output:\n base={base_text!r}\n rest={rest_text!r}"
+        )
+        print("[ok] perturb/restore round-trip reproduces baseline (radix-cache-off holds)")
+
+        # 5) committed ES update keeps every engine identical
+        seeds = [1, 2, 3, 4]
+        coeffs = [0.5, -0.5, 1.0, -1.0]
+        b.sync_after_update(seeds, coeffs, alpha=0.01, population_size=8)
+        cks2 = b.checksums()
+        if all(c is not None for c in cks2):
+            assert len(set(cks2)) == 1, f"engines drifted after update: {cks2}"
+            print("[ok] engines stay bit-identical after committed update")
+
+        # 6) save -> perturb -> load restores a consistent state across engines
+        tmp = tempfile.mktemp(suffix=".pth")
+        try:
+            b.save(tmp)
+            b.wait([b.perturb_async(0, 999, 0.05)])
+            b.load(tmp)
+            cks3 = b.checksums()
+            if all(c is not None for c in cks3):
+                assert len(set(cks3)) == 1, f"engines inconsistent after load: {cks3}"
+            print("[ok] save/perturb/load round-trip consistent")
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+        print(f"\nBACKEND E2E PASSED ({args.backend})")
+    finally:
+        b.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)

--- a/tests/e2e/train_improves.py
+++ b/tests/e2e/train_improves.py
@@ -1,0 +1,78 @@
+"""Tier-B behavioral e2e: a short REAL training run must not diverge and should
+trend upward, on either backend. ES is noisy, so this asserts non-divergence
+(second-half mean >= first-half mean - tol) rather than a strict monotone gate;
+the deterministic Tier-A tests carry the correctness weight.
+
+Runs ``es_at_scale/train.py`` as a subprocess and parses the per-iteration
+"Mean reward:" lines.
+
+  python tests/e2e/train_improves.py --backend vllm   --gpus 4,5
+  ES_SGLANG_PYTHON=.../sglang-es/bin/python \
+  python tests/e2e/train_improves.py --backend sglang --gpus 6,7
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backend", choices=["vllm", "sglang"], required=True)
+    ap.add_argument("--gpus", default="4,5")
+    ap.add_argument("--model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    ap.add_argument("--iters", type=int, default=12)
+    ap.add_argument("--pop", type=int, default=8)
+    ap.add_argument("--python", default=sys.executable)
+    ap.add_argument("--tol", type=float, default=0.02)
+    args = ap.parse_args()
+
+    n_engines = len([g for g in args.gpus.split(",") if g != ""])
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    cmd = [
+        args.python, "es_at_scale/train.py",
+        "--backend", args.backend,
+        "--task", "countdown",
+        "--model-name", args.model,
+        "--use-gpus", args.gpus,
+        "--n-vllm-engines", str(n_engines),
+        "--n-iterations", str(args.iters),
+        "--population-size", str(args.pop),
+        "--batch-size", "32", "--mini-batch-size", "32",
+        "--max-tokens", "256", "--sigma", "0.001",
+        "--eval-freq", "100000", "--logging", "none",
+        "--train-dataset", "datasets/train/countdown",
+        "--eval-dataset", "",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = repo + os.pathsep + env.get("PYTHONPATH", "")
+    print("[info] running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=repo, env=env, capture_output=True, text=True)
+    sys.stdout.write(proc.stdout[-4000:])
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr[-4000:])
+        print(f"FAILED: train.py exited {proc.returncode}")
+        sys.exit(1)
+
+    rewards = [float(x) for x in re.findall(r"Mean reward: ([-\d.eE+]+)", proc.stdout)]
+    print(f"[info] reward trajectory ({len(rewards)}): {rewards}")
+    if len(rewards) < 4:
+        print("FAILED: too few reward points parsed")
+        sys.exit(1)
+    if not all(r == r for r in rewards):  # NaN check
+        print("FAILED: non-finite reward encountered")
+        sys.exit(1)
+    half = len(rewards) // 2
+    first = sum(rewards[:half]) / half
+    second = sum(rewards[half:]) / (len(rewards) - half)
+    print(f"[info] first-half mean={first:.4f}  second-half mean={second:.4f}")
+    if second < first - args.tol:
+        print(f"FAILED: training diverged (second-half {second:.4f} << first-half {first:.4f})")
+        sys.exit(1)
+    print(f"\nTRAIN-IMPROVES PASSED ({args.backend}): non-divergent, trend {second - first:+.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_es_ops.py
+++ b/tests/test_es_ops.py
@@ -1,0 +1,150 @@
+"""Tier-A deterministic correctness test for the shared ES math (es_ops).
+
+Backend-free, CPU-only, fast. Run: ``python tests/test_es_ops.py``.
+Validates the perturb / restore / apply_update / snapshot / checksum primitives
+against hand-computed references so the extraction from the original
+worker_extension is provably behavior-preserving.
+"""
+
+import sys
+
+import torch
+
+from es_at_scale.backends import es_ops
+
+
+def make_model(seed=0):
+    torch.manual_seed(seed)
+    m = torch.nn.Sequential(
+        torch.nn.Linear(16, 8),
+        torch.nn.Linear(8, 4),
+    ).to(torch.float32)
+    return m
+
+
+def params_fn_of(m):
+    return lambda: m.named_parameters()
+
+
+def clone_state(m):
+    return {k: v.detach().clone() for k, v in m.named_parameters()}
+
+
+def test_perturb_reproducible_and_antithetic():
+    m = make_model()
+    pf = params_fn_of(m)
+    base = clone_state(m)
+
+    # same seed + scale -> identical perturbation (bit-exact, from the same base)
+    es_ops.perturb(pf, seed=1234, noise_scale=0.01)
+    after_a = clone_state(m)
+    es_ops.restore_from_snapshot(pf, base)
+    es_ops.perturb(pf, seed=1234, noise_scale=0.01)
+    after_b = clone_state(m)
+    es_ops.restore_from_snapshot(pf, base)
+    for k in after_a:
+        assert torch.equal(after_a[k], after_b[k]), f"perturb not reproducible for {k}"
+
+    # antithetic: around a ZERO base, perturb(+/-) is exactly +/- the signed noise
+    # (nonzero base would round asymmetrically -- that is the documented restore drift).
+    for p in m.parameters():
+        p.data.zero_()
+    zero = clone_state(m)
+    es_ops.perturb(pf, seed=1234, noise_scale=0.01, negate=False)
+    pos = clone_state(m)
+    es_ops.restore_from_snapshot(pf, zero)
+    es_ops.perturb(pf, seed=1234, noise_scale=0.01, negate=True)
+    for k, v in m.named_parameters():
+        assert torch.equal(v.detach(), -pos[k]), f"negate mismatch {k}"
+    es_ops.restore_from_snapshot(pf, zero)
+    print("[ok] perturb reproducible + antithetic")
+
+
+def test_snapshot_restore_bit_exact():
+    m = make_model()
+    pf = params_fn_of(m)
+    base = es_ops.snapshot(pf)
+    es_ops.perturb(pf, seed=7, noise_scale=0.05)
+    es_ops.restore_from_snapshot(pf, base)
+    for k, v in m.named_parameters():
+        assert torch.equal(v.detach(), base[k]), f"restore not bit-exact for {k}"
+    print("[ok] snapshot restore is bit-exact")
+
+
+def test_apply_update_matches_reference():
+    m = make_model()
+    pf = params_fn_of(m)
+    base = es_ops.snapshot(pf)
+
+    seeds = [11, 22, 33, 44]
+    coeffs = [0.5, -1.5, 2.0, 0.0]
+    alpha = 0.02
+    N = 8  # population_size (deliberately != len(seeds), as in the real algorithm)
+
+    # reference: theta + (alpha/N) * sum_i coeff_i * randn(seed_i), fp32 accumulate
+    ref = {}
+    for name, p in m.named_parameters():
+        acc = torch.zeros_like(p.data, dtype=torch.float32)
+        for i, s in enumerate(seeds):
+            g = torch.Generator(device=p.device).manual_seed(int(s))
+            noise = torch.randn(p.shape, dtype=p.dtype, device=p.device, generator=g)
+            acc += noise.to(torch.float32) * coeffs[i]
+        acc *= alpha / N
+        ref[name] = (base[name] + acc.to(p.dtype)).clone()
+
+    es_ops.apply_update(pf, seeds, coeffs, alpha, N)
+    for k, v in m.named_parameters():
+        assert torch.equal(v.detach(), ref[k]), f"apply_update mismatch for {k}"
+    print("[ok] apply_update matches hand-computed reference")
+
+
+def test_checksum_detects_change():
+    m = make_model()
+    pf = params_fn_of(m)
+    c0 = es_ops.checksum(pf)
+    c1 = es_ops.checksum(pf)
+    assert c0 == c1, "checksum not stable"
+    es_ops.perturb(pf, seed=99, noise_scale=1e-3)
+    c2 = es_ops.checksum(pf)
+    assert c2 != c0, "checksum failed to detect a change"
+    print("[ok] checksum stable + change-detecting")
+
+
+def test_apply_update_is_deterministic():
+    # apply_update is a pure deterministic function of (base, seeds, coeffs): two
+    # independent models with the same base + same update end bit-identical.
+    a, b = make_model(), make_model()
+    pa, pb = params_fn_of(a), params_fn_of(b)
+    # sync b to a's weights first
+    base = es_ops.snapshot(pa)
+    es_ops.restore_from_snapshot(pb, base)
+    assert es_ops.checksum(pa) == es_ops.checksum(pb)
+
+    seeds, coeffs = [1, 2, 3], [0.3, -0.7, 1.1]
+    es_ops.apply_update(pa, seeds, coeffs, 0.01, 5)
+    es_ops.apply_update(pb, seeds, coeffs, 0.01, 5)
+    assert es_ops.checksum(pa) == es_ops.checksum(pb), "engines drifted after identical update"
+    for (ka, va), (kb, vb) in zip(a.named_parameters(), b.named_parameters()):
+        assert torch.equal(va.detach(), vb.detach()), f"lockstep broken for {ka}"
+    print("[ok] independent engines stay bit-identical under the same update")
+
+
+def main():
+    tests = [
+        test_perturb_reproducible_and_antithetic,
+        test_snapshot_restore_bit_exact,
+        test_apply_update_matches_reference,
+        test_checksum_detects_change,
+        test_apply_update_is_deterministic,
+    ]
+    for t in tests:
+        t()
+    print("\nALL es_ops TESTS PASSED")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Make the rollout/inference engine pluggable behind an ESBackend interface, selectable via --backend {vllm,sglang}. The ES weight math (perturb / restore / update) is extracted into a single backend-agnostic es_ops module reused by every backend's worker; the trainer no longer imports vLLM directly.

- backends/base.py: ESBackend ABC + SamplingConfig + GenerationOutput
- backends/es_ops.py: shared torch-only ES math (installed in both envs)
- backends/vllm_backend.py: original vLLM mechanism behind the interface (unchanged)
- backends/sglang_{backend,worker,shim}.py: out-of-process SGLang engines in a dedicated conda env, driven over ZeroMQ. The shim monkeypatches sglang's run_scheduler_process to inject es_* methods onto the spawned Scheduler (no SGLang fork).
- setup.py: split into [vllm]/[sglang] extras so the core is vLLM-free.

Both backends use identical weight logic: perturb in place, subtract-restore, apply the ES update on engine 0, then NCCL-broadcast engine-0's weights to every engine each iteration. SGLang builds the inter-engine group from its own StatelessProcessGroup + PyNcclCommunicator (pass an explicit libnccl path; enable the comm via change_state before broadcasting). 

Guardrails: SGLang launched with disable_radix_cache / disable_overlap_schedule; startup self-test; broadcast group asserts the NCCL comm is live.

The batch=100 gen_len=384 job shows a 15% speed up but it is too small to be conclusive.

The `doc/` maybe moved out of scope and we can have a readthedoc website if needed later.